### PR TITLE
Add real account and parody account for News topic listings

### DIFF
--- a/db/news_seeds.rb
+++ b/db/news_seeds.rb
@@ -1,0 +1,12 @@
+topic = Topic.create!(topic: "news")
+
+# Real / verified accounts
+cnn = TwitterHandle.create!(topic: topic, twitter_handle: "cnnbrk")
+bbc = TwitterHandle.create!(topic: topic, twitter_handle: "bbcsport")
+onion = TwitterHandle.create!(topic: topic, twitter_handle: "theonion")
+
+
+# Parody accounts
+TwitterHandle.create!(topic: topic, twitter_handle: "thefakecnn", real_twitter_handle_id: cnn.id)
+TwitterHandle.create!(topic: topic, twitter_handle: "bbcsporf", real_twitter_handle_id: bbc.id)
+TwitterHandle.create!(topic: topic, twitter_handle: "theon1on", real_twitter_handle_id: onion.id)


### PR DESCRIPTION
- Create one Topic "News"
- Add real and fake accounts for CNN, BBC Sports, and The Onion
- Each account listing is linked to the "News" topic

This is an update to #21 