### PR TITLE
Redirect `/` route to the `/topics` route

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -1,4 +1,4 @@
 # Homepage (Root path)
 get '/' do
-  erb :index
+  redirect "/topics"
 end


### PR DESCRIPTION
`/topics` is our entry point if we follow REST practices. So `/` should
redirect there.