### PR TITLE
Twitter API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /tmp/
 
 # Used by dotenv library to load environment variables.
-# .env
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem 'sinatra-activerecord'
 gem 'puma'
 gem 'tux'
 
+gem 'dotenv'
+gem 'twitter'
+
 # These gems are only installed when run as `bundle install --without production`
 group :development, :test do
   gem 'pry'
@@ -20,6 +23,6 @@ end
 
 # bundle install --without test --without development
 group :production do
-  # use postgres in production, or move outside a group if your app uses postgres for development and production 
+  # use postgres in production, or move outside a group if your app uses postgres for development and production
   gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,16 +14,37 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     backports (3.6.7)
     bond (0.5.1)
+    buftok (0.2.0)
     builder (3.2.2)
     coderay (1.1.0)
+    domain_name (0.5.20160615)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.1.1)
+    equalizer (0.0.10)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    http (1.0.4)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
+    naught (1.1.0)
     pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -46,6 +67,7 @@ GEM
       ripl (>= 0.7.0)
     shotgun (0.9.1)
       rack (>= 1.0)
+    simple_oauth (0.3.1)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -69,14 +91,29 @@ GEM
       ripl-multi_line (>= 0.2.4)
       ripl-rack (>= 0.2.0)
       sinatra (>= 1.2.1)
+    twitter (5.16.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (= 0.0.10)
+      faraday (~> 0.9.0)
+      http (~> 1.0)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport
+  dotenv
   pg
   pry
   puma
@@ -87,6 +124,7 @@ DEPENDENCIES
   sinatra-contrib
   sqlite3
   tux
+  twitter
 
 BUNDLED WITH
-   1.12.1
+   1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -11,10 +11,14 @@ namespace :db do
   end
 end
 
-namespace :generate do
+desc 'Global namespace that requires config/environment'
+task :get_env do
   require_relative "config/environment"
+end
+
+namespace :generate do
   desc 'Generates numbered tweets for every TwitterHandle in the database'
-  task :tweets do
+  task :tweets => :get_env do
     Tweet.destroy_all
     TwitterHandle.all.each do |handle|
       12.times do |number|

--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,35 @@ namespace :generate do
     end
   end
 end
+
+namespace :twitter do
+  require 'dotenv/tasks'
+  require 'twitter'
+
+  desc 'Load Twitter config parameters as environment variables from Dotenv'
+  task :dotenv => :get_env do
+    @TWITTER_ENV = Dotenv.load.select { |key, _| key.match(/TWITTER/) }
+  end
+
+  desc 'Pull Tweets'
+  task :pull_tweets => :dotenv do
+    # Clear the Tweets table before populating
+    Tweet.destroy_all
+
+    # Configure Twitter connection
+    config = {
+      consumer_key: @TWITTER_ENV['TWITTER_CONSUMER_KEY'],
+      consumer_secret: @TWITTER_ENV['TWITTER_CONSUMER_SECRET']
+    }
+    twitter_client = Twitter::REST::Client.new(config)
+
+    # Import tweets for all TwitterHandles and add them to the Tweets table
+    TwitterHandle.all.each do |listing|
+      handle = listing.twitter_handle
+      user_tweets = twitter_client.user_timeline("#{handle}")
+      user_tweets.each do |tweet|
+        listing.tweets.create(content: tweet.full_text)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a core piece of functionality to the app. It incorporates the Twitter API and adds functionality for populating the database with tweets from each user. 

- Modification to Gemfile to require two new gems, Dotenv and Twitter
- Modification to .gitignore to ensure that .env file is not tracked. This file and the Dotenv gem make authentication information available to the app through an environment variable. 
- Modification to Rakefile to add the task that populates the database with tweets. This involves a fix to the tweet generator function: it required the /config/environment file, which caused problems with subsequent namespacing in the Rakefile. 