### PR TITLE
Fix issue #49

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -18,7 +18,7 @@ get '/topics' do
   erb :'/topics/index.html'
 end
 
-get '/verify/:id' do
+get '/verify/:id' do |id|
   tweet = Tweet.find(id)
   session[:times] = (session[:times] || 0) + 1
   if tweet.twitter_handle.real_twitter_handle_id == nil


### PR DESCRIPTION
This fixes the error when verify crashed upon load. the id was not
accepted by the block leading to a crash.

This fixes issue #49 