### PR TITLE
Add json option to topics list

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -1,3 +1,4 @@
+require 'json'
 # Homepage (Root path)
 get '/' do
   redirect "/topics"
@@ -16,7 +17,11 @@ end
 
 get '/topics' do
   @topics = Topic.all.order(:topic)
-  erb :'/topics/index.html'
+  unless params['json']
+    erb :'/topics/index.html'
+  else
+    Topic.all.to_a.to_json
+  end
 end
 
 get '/verify/:id' do |id|


### PR DESCRIPTION
Returns a json array, with json objects.

the keys on the json objects are:
`id`: _Server side id of the topic_
`topic`: _Human readable topic name_
`created_at`: _DateTime when the topic was added to the database_
`updated_at`: _DateTime of last update of this topic in teh database_