### PR TITLE
Add Json output option to showing a topic

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -11,7 +11,18 @@ get '/topics/:id' do |id|
   end
   @real = @topics.sample.twitter_handles.where("real_twitter_handle_id is null").sample.tweets.sample
   @fake = TwitterHandle.where("real_twitter_handle_id = ?", [@real.twitter_handle.id]).sample.tweets.sample
-  erb :'topics/show.html'
+  if params['json'].nil?
+    erb :'topics/show.html'
+  else
+    {
+      real: @real.content,
+      fake: @fake.content,
+      topic: id,
+      real_handle: @real.twitter_handle.twitter_handle,
+      fake_handle: @fake.twitter_handle.twitter_handle,
+      tweet_topic: @real.twitter_handle.topic.topic,
+    }.to_json
+  end
 end
 
 get '/topics' do


### PR DESCRIPTION
Update to PR #64 

The json object returned has the keys
`real`: _Content of the real tweet_
`fake`: _Content of the fake tweet_
`real_handle`: _Handle of user who created the real tweet_
`fake_handle`: _Handle of user who created the fake tweet_
`tweet_topic`: _Topic of the tweets sent_
`topic`: topic the user had selected_