### PR TITLE
Add the topic string name to the route instead of the topic id

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -3,11 +3,11 @@ get '/' do
   redirect "/topics"
 end
 
-get '/topics/:id' do |id|
-  session[:topic] = id
+get '/topics/:name' do |name|
+  session[:topic] = name
   @topics = Topic.all
-  unless id == "all"
-    @topics = [Topic.find(id)]
+  unless name == "all"
+    @topics = [Topic.find_by(topic: name)]
   end
   @real = @topics.sample.twitter_handles.where("real_twitter_handle_id is null").sample.tweets.sample
   @fake = TwitterHandle.where("real_twitter_handle_id = ?", [@real.twitter_handle.id]).sample.tweets.sample

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -17,7 +17,7 @@
         <% @topics.each do |topic| %>
           <li>
             <div>
-              <a href="/topics/<%=topic.id%>">
+              <a href="/topics/<%=topic.topic%>">
                 <div>
                   <%=topic.topic%>
                 </div>


### PR DESCRIPTION
This is in regards to Emily's enhancement #56 
- actions.rb finds Topic by topic instead of id
- route in index.html.erb uses topic.topic