### PR TITLE
Show number of real accounts for each topic on topics page

### DIFF
--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -11,7 +11,7 @@
       <div class="collection-header center"><h4>Or, select a topic!</h4></div>
       <% @topics.each do |topic| %>
         <a href="/topics/<%=topic.topic%>" class="collection-item">
-          <%=topic.topic%>
+          <%=topic.topic%> (<%=topic.twitter_handles.count%>)
         </a>
       <% end %>
     </div>


### PR DESCRIPTION
Displays the number of real accounts present for each topic in brackets after the topic name. Nothing fancy but it's there!